### PR TITLE
fixing exception in logging raised if instance is dict

### DIFF
--- a/nova_contrail_vif/contrailvif.py
+++ b/nova_contrail_vif/contrailvif.py
@@ -164,8 +164,7 @@ class VRouterVIFDriver(LibvirtBaseVIFDriver):
             from pprint import pformat
             LOG.error(_("Error in plug: %s locals: %s instance %s"
                        %(str(e), pformat(locals()),
-                         pformat(instance.__dict__))))
-    #end plug
+                         pformat(instance) if isinstance(instance, dict) else pformat(instance.__dict__))))
 
     def unplug(self, instance, vif):
         """Unplug the VIF from the network by deleting the port from
@@ -194,7 +193,7 @@ class VRouterVIFDriver(LibvirtBaseVIFDriver):
             from pprint import pformat
             LOG.error(_("Error in unplug: %s locals: %s instance %s"
                        %(str(e), pformat(locals()),
-                         pformat(instance.__dict__))))
+                         pformat(instance) if isinstance(instance, dict) else pformat(instance.__dict__))))
 
     #end unplug
 #end class VRouterVIFDriver


### PR DESCRIPTION
cherry picking the change for https://launchpad.net/bugs/1453332

fixing exception in logging raised if instance is dict

Change-Id: Iec215c91be621cf6f05e7d28e7a5828ab3283dc5

Conflicts:
	nova_contrail_vif/contrailvif.py

https://review.opencontrail.org/#/c/10152/